### PR TITLE
Fix mssql template

### DIFF
--- a/dbdeploy-core/src/main/resources/mssql_apply.ftl
+++ b/dbdeploy-core/src/main/resources/mssql_apply.ftl
@@ -11,9 +11,6 @@ INSERT INTO ${changeLogTableName} (change_number, complete_dt, applied_by, descr
  VALUES (${script.id?c}, getdate(), user_name(), '${script.description}')
 GO
 
-COMMIT
-GO
-
 -- END CHANGE SCRIPT ${script}
 
 [/#list]

--- a/dbdeploy-core/src/main/resources/mssql_undo.ftl
+++ b/dbdeploy-core/src/main/resources/mssql_undo.ftl
@@ -10,9 +10,6 @@ ${script.undoContent}
 DELETE FROM ${changeLogTableName} WHERE change_number = ${script.id?c}
 GO
 
-COMMIT
-GO
-
 -- END UNDO OF CHANGE SCRIPT ${script}
 
 [/#list]

--- a/dbdeploy-core/src/test/resources/com/dbdeploy/database/mssql_expected.sql
+++ b/dbdeploy-core/src/test/resources/com/dbdeploy/database/mssql_expected.sql
@@ -7,9 +7,6 @@ INSERT INTO changelog (change_number, complete_dt, applied_by, description)
  VALUES (1, getdate(), user_name(), '001_change.sql')
 GO
 
-COMMIT
-GO
-
 -- END CHANGE SCRIPT #1: 001_change.sql
 
 
@@ -19,9 +16,6 @@ GO
 
 INSERT INTO changelog (change_number, complete_dt, applied_by, description)
  VALUES (2, getdate(), user_name(), '002_change.sql')
-GO
-
-COMMIT
 GO
 
 -- END CHANGE SCRIPT #2: 002_change.sql


### PR DESCRIPTION
Hi Graham,

I use dbdeploy with Microsoft SQL Server. I have deleted the commit instruction in the mssql template as it was not preceded by a begin transaction.
This was causing the following error message when executing it with SQL Server client:
"The COMMIT TRANSACTION request has no corresponding BEGIN TRANSACTION."

I propose that transactions be managed directly in delta/change scripts made by dbdeploy users for Microsoft SQL Server specifically.

Thanks
