### PR TITLE
Fix for Issue 76, default sql directory in maven plugin

### DIFF
--- a/maven-dbdeploy-plugin/src/main/java/com/dbdeploy/mojo/CreateChangeScriptMojo.java
+++ b/maven-dbdeploy-plugin/src/main/java/com/dbdeploy/mojo/CreateChangeScriptMojo.java
@@ -37,7 +37,7 @@ public class CreateChangeScriptMojo extends AbstractMojo {
     /**
      * Directory where change scripts reside.
      *
-     * @parameter expression="${dbdeploy.scriptdirectory}" default-value="${project.src.directory}/main/sql"
+     * @parameter expression="${dbdeploy.scriptdirectory}" default-value="${project.basedir}/src/main/sql"
      * @required
      */
     private File scriptdirectory;


### PR DESCRIPTION
This is a simple change that fixes Issue 76.  The property ${project.src.directory}, which the maven plugin depends on, does not seem to exist in either my maven 2 or maven 3 installs that I have.  I have replaced it with the property ${project.basedir}.
