### PR TITLE
Issue 41: Ablility to ignore scripts via the maven plugin

### DIFF
--- a/dbdeploy-core/src/main/java/com/dbdeploy/DbDeploy.java
+++ b/dbdeploy-core/src/main/java/com/dbdeploy/DbDeploy.java
@@ -14,6 +14,7 @@ import com.dbdeploy.scripts.DirectoryScanner;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.util.List;
 
 public class DbDeploy {
 	private String url;
@@ -31,6 +32,7 @@ public class DbDeploy {
 	private String delimiter = ";";
 	private DelimiterType delimiterType = DelimiterType.normal;
 	private File templatedir;
+	private List<Long> changeScriptIdsToIgnore;
 
 	public void setDriver(String driver) {
 		this.driver = driver;
@@ -79,6 +81,10 @@ public class DbDeploy {
 	public void setLineEnding(LineEnding lineEnding) {
 		this.lineEnding = lineEnding;
 	}
+	
+	public void setChangeScriptIdsToIgnore(List<Long> changeScriptIdsToIgnore) {
+		this.changeScriptIdsToIgnore = changeScriptIdsToIgnore;
+	}
 
 	public void go() throws Exception {
 		System.err.println(getWelcomeString());
@@ -93,7 +99,7 @@ public class DbDeploy {
 				new DatabaseSchemaVersionManager(queryExecuter, changeLogTableName);
 
 		ChangeScriptRepository changeScriptRepository =
-				new ChangeScriptRepository(new DirectoryScanner(encoding).getChangeScriptsForDirectory(scriptdirectory));
+				new ChangeScriptRepository(new DirectoryScanner(encoding).getChangeScriptsForDirectory(scriptdirectory, changeScriptIdsToIgnore));
 
 		ChangeScriptApplier doScriptApplier;
 
@@ -223,5 +229,9 @@ public class DbDeploy {
 
 	public LineEnding getLineEnding() {
 		return lineEnding;
+	}
+	
+	public List<Long> getChangeScriptIdsToIgnore() {
+		return changeScriptIdsToIgnore;
 	}
 }

--- a/dbdeploy-core/src/main/java/com/dbdeploy/scripts/DirectoryScanner.java
+++ b/dbdeploy-core/src/main/java/com/dbdeploy/scripts/DirectoryScanner.java
@@ -16,7 +16,7 @@ public class DirectoryScanner {
         this.encoding = encoding;
     }
 	
-	public List<ChangeScript> getChangeScriptsForDirectory(File directory)  {
+	public List<ChangeScript> getChangeScriptsForDirectory(File directory, List<Long> changeScriptIdsToIgnore)  {
 		try {
 			System.err.println("Reading change scripts from directory " + directory.getCanonicalPath() + "...");
 		} catch (IOException e1) {
@@ -30,7 +30,13 @@ public class DirectoryScanner {
 				String filename = file.getName();
 				try {
 					long id = filenameParser.extractIdFromFilename(filename);
-					scripts.add(new ChangeScript(id, file, encoding));
+					if (changeScriptIdsToIgnore == null) {
+						scripts.add(new ChangeScript(id, file, encoding));
+					} else {
+						if (!changeScriptIdsToIgnore.contains(id)) {
+							scripts.add(new ChangeScript(id, file, encoding));
+						}
+					}
 				} catch (UnrecognisedFilenameException e) {
 					// ignore
 				}

--- a/dbdeploy-core/src/test/java/com/dbdeploy/scripts/DirectoryScannerTest.java
+++ b/dbdeploy-core/src/test/java/com/dbdeploy/scripts/DirectoryScannerTest.java
@@ -1,0 +1,44 @@
+package com.dbdeploy.scripts;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class DirectoryScannerTest {
+
+	@Test
+	public void shouldIgnoreChangeScriptsThatAreInTheIgnoreList() throws Exception {
+		DirectoryScanner scanner = new DirectoryScanner("UTF-8");
+		List<Long> changeScriptIdsToIgnore = Arrays.asList(new Long[] { 2l });
+		
+		File file1 = mockFile("1_file1");
+		File file2 = mockFile("2_file2");
+		File file3 = mockFile("3_file3");
+		File[] files = new File[] { file1, file2, file3 };
+		
+		File directory =  Mockito.mock(File.class);
+		when(directory.listFiles()).thenReturn(files);
+		
+		List<ChangeScript> changeScripts = scanner.getChangeScriptsForDirectory(directory, changeScriptIdsToIgnore);
+		
+		for (ChangeScript changeScript : changeScripts) {
+			assertThat(changeScript.getFile(), not(equalTo(file2)));
+		}
+	}
+
+	private File mockFile(String fileName) {
+		File file = Mockito.mock(File.class);
+		when(file.isFile()).thenReturn(true);
+		when(file.getName()).thenReturn(fileName);
+		return file;
+	}
+	
+}

--- a/maven-dbdeploy-plugin/pom.xml
+++ b/maven-dbdeploy-plugin/pom.xml
@@ -37,6 +37,11 @@
             <version>2.0</version>
         </dependency>
         <dependency>
+			<groupId>org.jasypt</groupId>
+			<artifactId>jasypt</artifactId>
+			<version>1.9.2</version>
+		</dependency> 
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>dbdeploy-core</artifactId>
             <version>${project.version}</version>

--- a/maven-dbdeploy-plugin/src/main/java/com/dbdeploy/mojo/AbstractDbDeployMojo.java
+++ b/maven-dbdeploy-plugin/src/main/java/com/dbdeploy/mojo/AbstractDbDeployMojo.java
@@ -16,6 +16,8 @@ package com.dbdeploy.mojo;
  * limitations under the License.
  */
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
@@ -118,6 +120,13 @@ public abstract class AbstractDbDeployMojo extends AbstractMojo {
      */
     protected Long lastChangeToApply;
 
+    /**
+    * The change scripts to ignore.
+    *
+    * @parameter expression="${dbdeploy.changeScriptIdsToIgnore}"
+    */
+	protected List<String> changeScriptIdsToIgnore;
+
     protected DbDeploy getConfiguredDbDeploy() {
         DbDeploy dbDeploy = new DbDeploy();
         dbDeploy.setScriptdirectory(scriptdirectory);
@@ -149,10 +158,15 @@ public abstract class AbstractDbDeployMojo extends AbstractMojo {
 	    if (lineEnding != null) {
 		    dbDeploy.setLineEnding(LineEnding.valueOf(lineEnding));
 	    }
+	    
+	    if (changeScriptIdsToIgnore != null && !changeScriptIdsToIgnore.isEmpty()) {
+	    	List<Long> changeScriptLongIdsToIgnore = toLongs(changeScriptIdsToIgnore);
+			dbDeploy.setChangeScriptIdsToIgnore(changeScriptLongIdsToIgnore);
+	    }
 
         return dbDeploy;
     }
-    
+
 	private String getPassword() {
 		return isEncrypted(password) ? unwrapAndDecrypt(password) : password;
 	}
@@ -182,5 +196,13 @@ public abstract class AbstractDbDeployMojo extends AbstractMojo {
 		} catch (Exception e) {
 			throw new RuntimeException("There was an error decrypting the password. Make sure it is a valid encrypted password.", e);
 		}
+	}
+	
+	private List<Long> toLongs(List<String> stringIds) {
+		List<Long> longIds = new ArrayList<Long>();
+		for (String id : stringIds) {
+			longIds.add(Long.valueOf(id));
+		}
+		return longIds;
 	}
 }

--- a/maven-dbdeploy-plugin/src/main/java/com/dbdeploy/mojo/AbstractDbDeployMojo.java
+++ b/maven-dbdeploy-plugin/src/main/java/com/dbdeploy/mojo/AbstractDbDeployMojo.java
@@ -17,8 +17,10 @@ package com.dbdeploy.mojo;
  */
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 
@@ -121,11 +123,11 @@ public abstract class AbstractDbDeployMojo extends AbstractMojo {
     protected Long lastChangeToApply;
 
     /**
-    * The change scripts to ignore.
+    * The change scripts to ignore as comma separated values.
     *
     * @parameter expression="${dbdeploy.changeScriptIdsToIgnore}"
     */
-	protected List<String> changeScriptIdsToIgnore;
+	protected String changeScriptIdsToIgnore;
 
     protected DbDeploy getConfiguredDbDeploy() {
         DbDeploy dbDeploy = new DbDeploy();
@@ -159,8 +161,8 @@ public abstract class AbstractDbDeployMojo extends AbstractMojo {
 		    dbDeploy.setLineEnding(LineEnding.valueOf(lineEnding));
 	    }
 	    
-	    if (changeScriptIdsToIgnore != null && !changeScriptIdsToIgnore.isEmpty()) {
-	    	List<Long> changeScriptLongIdsToIgnore = toLongs(changeScriptIdsToIgnore);
+	    if (StringUtils.isNotBlank(changeScriptIdsToIgnore)) {
+	    	List<Long> changeScriptLongIdsToIgnore = toListOfLongs(changeScriptIdsToIgnore);
 			dbDeploy.setChangeScriptIdsToIgnore(changeScriptLongIdsToIgnore);
 	    }
 
@@ -198,11 +200,13 @@ public abstract class AbstractDbDeployMojo extends AbstractMojo {
 		}
 	}
 	
-	private List<Long> toLongs(List<String> stringIds) {
+	private List<Long> toListOfLongs(String idsAsString) {
+		List<String> stringIds = Arrays.asList(StringUtils.split(idsAsString, ","));
 		List<Long> longIds = new ArrayList<Long>();
-		for (String id : stringIds) {
-			longIds.add(Long.valueOf(id));
+		for (String stringId : stringIds) {
+			longIds.add(Long.valueOf(stringId));
 		}
 		return longIds;
 	}
+		
 }

--- a/maven-dbdeploy-plugin/src/test/resources/unit/test/db-scripts-plugin-config.xml
+++ b/maven-dbdeploy-plugin/src/test/resources/unit/test/db-scripts-plugin-config.xml
@@ -12,6 +12,11 @@
                     <dbms>hsql</dbms>
                     <outputfile>apply.sql</outputfile>
                     <undoOutputfile>undo.sql</undoOutputfile>
+                    <changeScriptIdsToIgnore>
+                    	<id>1</id>
+                    	<id>2</id>
+                    	<id>3</id>
+                    </changeScriptIdsToIgnore>
                 </configuration>
             </plugin>
         </plugins>

--- a/maven-dbdeploy-plugin/src/test/resources/unit/test/db-scripts-plugin-config.xml
+++ b/maven-dbdeploy-plugin/src/test/resources/unit/test/db-scripts-plugin-config.xml
@@ -12,11 +12,7 @@
                     <dbms>hsql</dbms>
                     <outputfile>apply.sql</outputfile>
                     <undoOutputfile>undo.sql</undoOutputfile>
-                    <changeScriptIdsToIgnore>
-                    	<id>1</id>
-                    	<id>2</id>
-                    	<id>3</id>
-                    </changeScriptIdsToIgnore>
+                    <changeScriptIdsToIgnore>1,2,3</changeScriptIdsToIgnore>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This pull request is an attempt to resolve issue #41 (https://code.google.com/p/dbdeploy/issues/detail?id=41). It allows you specify a list of change script Ids in a new changeScriptIdsToIgnore element in the maven plugin configuration. These script Ids will be ignored when generating the change scripts to be included. The  capability has not been implemented for the CLI or Ant task, but if there is interest I would be happy to help implement.
