### PR TITLE
Issue 81: Allow using encrypted password in the dbdeploy maven plugin

### DIFF
--- a/maven-dbdeploy-plugin/pom.xml
+++ b/maven-dbdeploy-plugin/pom.xml
@@ -37,6 +37,11 @@
             <version>2.0</version>
         </dependency>
         <dependency>
+			<groupId>org.jasypt</groupId>
+			<artifactId>jasypt</artifactId>
+			<version>1.9.2</version>
+		</dependency> 
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>dbdeploy-core</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
Issue 81: Allow using encrypted password in the dbdeploy maven plugin pom configuration. Excepts encryptionKey as a VM argument such as -DencryptionKey=mysecretkey and the password in the pom.xml is enclosed within ENC() such as ENC(G7+yPDK2Ci8fpu9OV67ZNw==).
